### PR TITLE
feat: implement piece snapping with satisfying visual feedback

### DIFF
--- a/src/app/puzzle/PuzzleManager.ts
+++ b/src/app/puzzle/PuzzleManager.ts
@@ -11,6 +11,9 @@ export type PuzzleManagerOptions = {
   pieceHeight: number;
   scatterPadding?: number;
   snapTolerancePx?: number;
+
+  // Optional: where scatter starts as ratio of board height (0.0 top → 1.0 bottom)
+  scatterStartYRatio?: number;
 };
 
 export type PuzzleManagerEvents = {
@@ -32,6 +35,9 @@ export class PuzzleManager {
   private boardHeight: number;
   private snapTolerancePx: number;
 
+  // Scatter tuning
+  private scatterStartYRatio: number;
+
   constructor(options: PuzzleManagerOptions, events: PuzzleManagerEvents = {}) {
     const {
       imageUrl,
@@ -42,12 +48,15 @@ export class PuzzleManager {
       pieceHeight,
       scatterPadding = 16,
       snapTolerancePx = 18,
+      scatterStartYRatio = 0.3,
     } = options;
 
     this.events = events;
     this.boardWidth = boardWidth;
     this.boardHeight = boardHeight;
     this.snapTolerancePx = snapTolerancePx;
+
+    this.scatterStartYRatio = scatterStartYRatio;
 
     this.drag = { activeId: null, offsetX: 0, offsetY: 0 };
     this.zCounter = 10;
@@ -83,7 +92,6 @@ export class PuzzleManager {
     this.boardWidth = boardWidth;
     this.boardHeight = boardHeight;
 
-    // Clamp all pieces into the new bounds
     this.state = {
       ...this.state,
       pieces: this.state.pieces.map((piece) => {
@@ -104,7 +112,6 @@ export class PuzzleManager {
     const piece = this.findPiece(pieceId);
     if (!piece) return;
 
-    // For MVP, placed pieces are locked
     if (piece.isPlaced) return;
 
     this.drag = {
@@ -116,7 +123,9 @@ export class PuzzleManager {
     this.zCounter += 1;
     this.state = {
       ...this.state,
-      pieces: this.state.pieces.map((p) => (p.id === pieceId ? { ...p, z: this.zCounter } : p)),
+      pieces: this.state.pieces.map((p) =>
+        p.id === pieceId ? { ...p, z: this.zCounter } : p
+      ),
     };
   }
 
@@ -138,19 +147,17 @@ export class PuzzleManager {
 
     this.state = {
       ...this.state,
-      pieces: this.state.pieces.map((p) => (p.id === activeId ? { ...p, x: nextX, y: nextY } : p)),
+      pieces: this.state.pieces.map((p) =>
+        p.id === activeId ? { ...p, x: nextX, y: nextY } : p
+      ),
     };
   }
 
-  /**
-   * Drop the active piece.
-   * For #32: attempt snap on drop, then release drag.
-   */
   pointerUp() {
     const activeId = this.drag.activeId;
     if (!activeId) return;
 
-    // Attempt snap BEFORE clearing drag (trySnapActivePiece uses drag.activeId)
+    // Attempt snap BEFORE clearing drag (trySnapActivePiece reads drag.activeId)
     const snapped = this.trySnapActivePiece();
 
     // Always release drag
@@ -161,6 +168,21 @@ export class PuzzleManager {
     if (!snapped) {
       this.recomputeDerivedState();
     }
+  }
+
+  // Called by UI after the snap-pop animation ends
+  clearJustSnapped(pieceId: PieceId) {
+    const piece = this.findPiece(pieceId);
+    if (!piece) return;
+
+    if (!piece.justSnapped) return;
+
+    this.state = {
+      ...this.state,
+      pieces: this.state.pieces.map((p) =>
+        p.id === pieceId ? { ...p, justSnapped: false } : p
+      ),
+    };
   }
 
   trySnapActivePiece(): boolean {
@@ -181,6 +203,9 @@ export class PuzzleManager {
       x: piece.targetX,
       y: piece.targetY,
       isPlaced: true,
+
+      // Visual cue trigger
+      justSnapped: true,
     };
 
     this.state = {
@@ -224,7 +249,7 @@ export class PuzzleManager {
 
     const total = grid.cols * grid.rows;
 
-    // Target positions: simple grid layout within the board
+    // Targets start at (16,16) for now (matches your slice math in PlayScreen)
     const targetStartX = 16;
     const targetStartY = 16;
 
@@ -237,11 +262,13 @@ export class PuzzleManager {
       const targetX = targetStartX + col * pieceWidth;
       const targetY = targetStartY + row * pieceHeight;
 
-      // Scatter start positions (roughly lower area by default)
       const scatterMinX = scatterPadding;
       const scatterMaxX = Math.max(scatterPadding, this.boardWidth - pieceWidth - scatterPadding);
 
-      const scatterMinY = Math.max(scatterPadding, this.boardHeight * 0.55);
+      const scatterMinY = Math.max(
+        scatterPadding,
+        Math.floor(this.boardHeight * this.scatterStartYRatio)
+      );
       const scatterMaxY = Math.max(scatterMinY, this.boardHeight - pieceHeight - scatterPadding);
 
       const x = this.rand(scatterMinX, scatterMaxX);
@@ -257,6 +284,7 @@ export class PuzzleManager {
         targetX,
         targetY,
         isPlaced: false,
+        justSnapped: false,
       });
     }
 

--- a/src/app/puzzle/types.ts
+++ b/src/app/puzzle/types.ts
@@ -17,6 +17,7 @@ export type Piece = {
   targetX: number;
   targetY: number;
   isPlaced: boolean;
+  justSnapped?: boolean;
 };
 
 export type DragState = {

--- a/src/app/screens/Play/PlayScreen.module.css
+++ b/src/app/screens/Play/PlayScreen.module.css
@@ -64,21 +64,33 @@
 .piece {
   position: absolute;
   border-radius: 10px;
-
-  background-color: transparent;
-
   border: 1px solid rgba(0, 0, 0, 0.18);
   box-shadow: 0 10px 18px rgba(0, 0, 0, 0.12);
   touch-action: none;
   user-select: none;
   cursor: grab;
+
+  /* Helps the snap-pop feel crisp */
+  will-change: transform;
 }
 
-.piece::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 10px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
-  pointer-events: none;
+.piece:active {
+  cursor: grabbing;
+}
+
+/* Tiny snap cue */
+.snapped {
+  animation: snap-pop 120ms ease-out;
+}
+
+@keyframes snap-pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
 }

--- a/src/app/screens/Play/PlayScreen.tsx
+++ b/src/app/screens/Play/PlayScreen.tsx
@@ -8,10 +8,6 @@ import type { PuzzleState } from "@/puzzle/types";
 
 const STORAGE_KEY = "phuzzle:imageDataUrl";
 
-// IMPORTANT: must match PuzzleManager's targetStartX/targetStartY
-const TARGET_ORIGIN_X = 16;
-const TARGET_ORIGIN_Y = 16;
-
 export function PlayScreen() {
   const nav = useNavigate();
 
@@ -25,29 +21,9 @@ export function PlayScreen() {
   const grid = useMemo(() => ({ rows: 4, cols: 5 }), []);
   const pieceSize = useMemo(() => ({ w: 72, h: 72 }), []);
 
-  // No image, no play
-  if (!imgUrl) {
-    return (
-      <div className={styles.page}>
-        <header className={styles.topBar}>
-          <button className={styles.iconBtn} onClick={() => nav("/")}>
-            Back
-          </button>
-          <div className={styles.title}>Phuzzle</div>
-          <div />
-        </header>
-
-        <main className={styles.main}>
-          <section className={styles.board}>
-            No image selected. Go back and upload one.
-          </section>
-        </main>
-      </div>
-    );
-  }
-
-  // Initialize manager once
+  // Initialize manager once (only if we have an image)
   useEffect(() => {
+    if (!imgUrl) return;
     if (managerRef.current) return;
 
     const initialBoardWidth = 900;
@@ -63,6 +39,7 @@ export function PlayScreen() {
         pieceHeight: pieceSize.h,
         scatterPadding: 16,
         snapTolerancePx: 18,
+        scatterStartYRatio: 0.3,
       },
       {
         onPuzzleComplete: (s) => console.log("[Phuzzle] puzzle complete", s),
@@ -73,7 +50,7 @@ export function PlayScreen() {
     setState(managerRef.current.getState());
   }, [grid, imgUrl, pieceSize.w, pieceSize.h]);
 
-  // Keep manager in sync with actual board DOM size
+  // Measure board and set board size on manager
   useEffect(() => {
     const board = boardRef.current;
     const mgr = managerRef.current;
@@ -104,8 +81,6 @@ export function PlayScreen() {
       const mgr = managerRef.current;
       if (!mgr) return;
 
-      // Later, when you want snapping on drop:
-      // mgr.trySnapActivePiece();
       mgr.pointerUp();
       setState(mgr.getState());
 
@@ -124,6 +99,25 @@ export function PlayScreen() {
       delete (window as any).__phuzzleAttachDragListeners;
     };
   }, []);
+
+  // No image: friendly message
+  if (!imgUrl) {
+    return (
+      <div className={styles.page}>
+        <header className={styles.topBar}>
+          <button className={styles.iconBtn} onClick={() => nav("/")}>
+            Back
+          </button>
+          <div className={styles.title}>Phuzzle</div>
+          <div />
+        </header>
+
+        <main className={styles.main}>
+          <section className={styles.board}>No image selected. Go back and upload one.</section>
+        </main>
+      </div>
+    );
+  }
 
   if (!state) {
     return (
@@ -144,7 +138,7 @@ export function PlayScreen() {
     );
   }
 
-  // Size of the assembled "full" image that every tile samples from
+  // Assembled image size (defines the "big" image each piece samples from)
   const assembledW = state.grid.cols * pieceSize.w;
   const assembledH = state.grid.rows * pieceSize.h;
 
@@ -168,18 +162,18 @@ export function PlayScreen() {
       <main className={styles.main}>
         <section className={styles.board} ref={boardRef}>
           {state.pieces.map((piece) => {
-            // Which tile is this in the assembled grid?
-            const col = (piece.targetX - TARGET_ORIGIN_X) / piece.w;
-            const row = (piece.targetY - TARGET_ORIGIN_Y) / piece.h;
+            // Assumes targets start at (16,16) in PuzzleManager.
+            const bgX = piece.targetX - 16;
+            const bgY = piece.targetY - 16;
 
-            // Pixel offsets for backgroundPosition
-            const bgX = Math.round(col * piece.w);
-            const bgY = Math.round(row * piece.h);
+            const className = piece.justSnapped
+              ? `${styles.piece} ${styles.snapped}`
+              : styles.piece;
 
             return (
               <div
                 key={piece.id}
-                className={styles.piece}
+                className={className}
                 style={{
                   left: piece.x,
                   top: piece.y,
@@ -192,6 +186,14 @@ export function PlayScreen() {
                   backgroundSize: `${assembledW}px ${assembledH}px`,
                   backgroundPosition: `-${bgX}px -${bgY}px`,
                 }}
+                onAnimationEnd={() => {
+                  const mgr = managerRef.current;
+                  if (!mgr) return;
+
+                  // Clear the flag so future snaps can pop again
+                  mgr.clearJustSnapped(piece.id);
+                  setState(mgr.getState());
+                }}
                 onPointerDown={(e) => {
                   const mgr = managerRef.current;
                   if (!mgr) return;
@@ -200,9 +202,7 @@ export function PlayScreen() {
                   mgr.pointerDown(piece.id, e.clientX, e.clientY, pieceRect);
                   setState(mgr.getState());
 
-                  const attach = (window as any).__phuzzleAttachDragListeners as
-                    | undefined
-                    | (() => void);
+                  const attach = (window as any).__phuzzleAttachDragListeners as undefined | (() => void);
                   attach?.();
                 }}
                 title={piece.id}


### PR DESCRIPTION
## Description

Implement piece snapping with satisfying visual feedback

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

- [x] I have tested these changes locally
- [x] I have tested these changes in multiple browsers/environments if applicable

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if needed

## How to Test

# PR Testing Steps – Puzzle Piece Snapping

## Goal
Verify that puzzle pieces snap into place when dragged close to their correct target position, with a small visual cue.

## Setup
1. Pull the branch and install dependencies:

   ``bash 
    npm install
    ```
2. Start the dev server:
  ```bash
   npm run dev
   ```
   
3. Open the app in the browser.

## Test Steps
1. Start a new game and upload a simple test image (ideally a grid-based image).
2. Navigate to the Play screen.
3. Drag a puzzle piece around the board.
4. Slowly move the piece near its correct position (top-left grid area is easiest to verify).
5. Release the mouse/pointer.

## Expected Behavior
- When the piece is within snap tolerance:
  - It snaps cleanly into its target position.
  - The piece briefly scales up slightly (visual feedback).
  - The piece becomes locked and cannot be dragged again.
- When the piece is not within tolerance:
  - It stays where released.
  - No snap animation occurs.

## Regression Checks
- Dragging still works for unsnapped pieces.
- Snapped pieces do not jitter or move.
- No console errors or warnings appear.
- PuzzleManager state updates correctly.

## Notes
This ticket implements target-position snapping only.
Neighbor-to-neighbor snapping and classic jigsaw edges are intentionally out of scope.


## Screenshots (if applicable)

**N/A**

## Additional Notes

**N/A**
