### PR TITLE
Feature/53 mvp persist full puzzle state across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,27 +178,10 @@ npm run dev
 │   │   ├── feature_request.yml
 │   │   └── question_discussion.yml
 │   ├── workflows
-│   │   └── Phuzzle.yml
+│   │   ├── Phuzzle.yml
+│   │   └── vercel-production.yml
 │   └── pull_request_template.md
 ├── .husky
-│   ├── _
-│   │   ├── .gitignore
-│   │   ├── applypatch-msg
-│   │   ├── commit-msg
-│   │   ├── h
-│   │   ├── husky.sh
-│   │   ├── post-applypatch
-│   │   ├── post-checkout
-│   │   ├── post-commit
-│   │   ├── post-merge
-│   │   ├── post-rewrite
-│   │   ├── pre-applypatch
-│   │   ├── pre-auto-gc
-│   │   ├── pre-commit
-│   │   ├── pre-merge-commit
-│   │   ├── pre-push
-│   │   ├── pre-rebase
-│   │   └── prepare-commit-msg
 │   ├── pre-commit
 │   └── pre-push
 ├── .vite
@@ -242,6 +225,7 @@ npm run dev
 │   │   │   ├── colorUtils.ts
 │   │   │   ├── config.ts
 │   │   │   ├── PuzzleManager.ts
+│   │   │   ├── puzzleStorage.ts
 │   │   │   ├── shape.ts
 │   │   │   ├── SnapLogic.ts
 │   │   │   └── types.ts
@@ -265,8 +249,9 @@ npm run dev
 │   │   └── vite-env.d.ts
 │   └── types
 │       └── canvas-confetti.d.ts
+├── test-results
+│   └── .last-run.json
 ├── .env.development
-├── .eslintcache
 ├── .gitignore
 ├── .prettierignore
 ├── .prettierrc.yml
@@ -280,7 +265,9 @@ npm run dev
 ├── tsconfig.app.json
 ├── tsconfig.app.tsbuildinfo
 ├── tsconfig.json
-├── tsconfig.node.j
+├── tsconfig.node.json
+└── vite.config.ts
+
 
 </details>
 ```

--- a/src/app/puzzle/PuzzleManager.ts
+++ b/src/app/puzzle/PuzzleManager.ts
@@ -122,6 +122,52 @@ export class PuzzleManager {
     this.recomputeDerivedState();
   }
 
+  /**
+   * Restore piece positions from saved state.
+   * Call this after construction if you have saved state to restore.
+   */
+  restoreFromSaved(
+    savedPieces: Array<{
+      id: string;
+      x: number;
+      y: number;
+      z: number;
+      rotation: number;
+      isPlaced: boolean;
+      groupId: string;
+      inTray: boolean;
+    }>,
+  ): void {
+    // Create a map for quick lookup
+    const savedMap = new Map(savedPieces.map((p) => [p.id, p]));
+
+    // Update zCounter to be above all saved z values
+    const maxZ = Math.max(...savedPieces.map((p) => p.z), this.zCounter);
+    this.zCounter = maxZ + 1;
+
+    // Apply saved positions to pieces
+    this.state = {
+      ...this.state,
+      pieces: this.state.pieces.map((piece) => {
+        const saved = savedMap.get(piece.id);
+        if (!saved) return piece;
+
+        return {
+          ...piece,
+          x: saved.x,
+          y: saved.y,
+          z: saved.z,
+          rotation: saved.rotation,
+          isPlaced: saved.isPlaced,
+          groupId: saved.groupId,
+          inTray: saved.inTray,
+        };
+      }),
+    };
+
+    this.recomputeDerivedState();
+  }
+
   // ---------------- Public API ----------------
 
   getState(): PuzzleState {

--- a/src/app/puzzle/puzzleStorage.ts
+++ b/src/app/puzzle/puzzleStorage.ts
@@ -1,0 +1,122 @@
+// src/app/puzzle/puzzleStorage.ts
+
+import type { Piece, GridSize } from "./types";
+
+const PUZZLE_STATE_KEY = "phuzzle:puzzleState";
+
+/**
+ * Minimal piece data needed to restore state.
+ * We don't save shapePath (regenerated) or dimensions (computed from grid).
+ */
+type SavedPiece = {
+  id: string;
+  row: number;
+  col: number;
+  x: number;
+  y: number;
+  z: number;
+  rotation: number;
+  isPlaced: boolean;
+  groupId: string;
+  inTray: boolean;
+};
+
+export type SavedPuzzleState = {
+  version: 1;
+  imageUrl: string;
+  grid: GridSize;
+  pieces: SavedPiece[];
+  elapsedSeconds: number;
+  savedAt: number; // timestamp
+};
+
+/**
+ * Save current puzzle state to localStorage
+ */
+export function savePuzzleState(
+  imageUrl: string,
+  grid: GridSize,
+  pieces: Piece[],
+  elapsedSeconds: number,
+): void {
+  const savedPieces: SavedPiece[] = pieces.map((p) => ({
+    id: p.id,
+    row: p.row,
+    col: p.col,
+    x: p.x,
+    y: p.y,
+    z: p.z,
+    rotation: p.rotation,
+    isPlaced: p.isPlaced,
+    groupId: p.groupId,
+    inTray: p.inTray,
+  }));
+
+  const state: SavedPuzzleState = {
+    version: 1,
+    imageUrl,
+    grid,
+    pieces: savedPieces,
+    elapsedSeconds,
+    savedAt: Date.now(),
+  };
+
+  try {
+    localStorage.setItem(PUZZLE_STATE_KEY, JSON.stringify(state));
+  } catch (e) {
+    console.warn("Failed to save puzzle state:", e);
+  }
+}
+
+/**
+ * Load saved puzzle state from localStorage
+ */
+export function loadPuzzleState(): SavedPuzzleState | null {
+  try {
+    const raw = localStorage.getItem(PUZZLE_STATE_KEY);
+    if (!raw) return null;
+
+    const state = JSON.parse(raw) as SavedPuzzleState;
+
+    // Validate version
+    if (state.version !== 1) {
+      console.warn("Unknown puzzle state version:", state.version);
+      return null;
+    }
+
+    // Basic validation
+    if (!state.imageUrl || !state.grid || !state.pieces) {
+      return null;
+    }
+
+    return state;
+  } catch (e) {
+    console.warn("Failed to load puzzle state:", e);
+    return null;
+  }
+}
+
+/**
+ * Clear saved puzzle state
+ */
+export function clearPuzzleState(): void {
+  try {
+    localStorage.removeItem(PUZZLE_STATE_KEY);
+  } catch (e) {
+    console.warn("Failed to clear puzzle state:", e);
+  }
+}
+
+/**
+ * Check if there's a saved game that matches current settings
+ */
+export function hasSavedGame(imageUrl: string, grid: GridSize): boolean {
+  const saved = loadPuzzleState();
+  if (!saved) return false;
+
+  return (
+    saved.imageUrl === imageUrl &&
+    saved.grid.rows === grid.rows &&
+    saved.grid.cols === grid.cols
+  );
+}

--- a/src/app/screens/Play/PlayScreen.tsx
+++ b/src/app/screens/Play/PlayScreen.tsx
@@ -8,6 +8,11 @@ import { renderBoard } from "@/puzzle/canvas/renderBoard";
 import { pickPieceId } from "@/puzzle/canvas/pickPiece";
 import { PieceTray } from "@/components/PieceTray/PieceTray";
 import { getAverageColor } from "@/puzzle/colorUtils";
+import {
+  savePuzzleState,
+  loadPuzzleState,
+  clearPuzzleState,
+} from "@/puzzle/puzzleStorage";
 
 const STORAGE_KEY = "phuzzle:imageDataUrl";
 const GRID_KEY = "phuzzle:gridSize";
@@ -89,10 +94,24 @@ export function PlayScreen() {
     boardSizeRef.current = { w: boardW, h: boardH };
 
     const pieceSize = computeTileSize(boardW, boardH);
+    const imageUrl = localStorage.getItem(STORAGE_KEY) || "";
+
+    // Check for saved game state
+    const savedState = loadPuzzleState();
+    const hasSavedGame =
+      savedState &&
+      savedState.imageUrl === imageUrl &&
+      savedState.grid.rows === grid.rows &&
+      savedState.grid.cols === grid.cols;
+
+    // Restore elapsed time if we have a saved game
+    if (hasSavedGame && savedState) {
+      setElapsedSeconds(savedState.elapsedSeconds);
+    }
 
     const next = new PuzzleManager(
       {
-        imageUrl: localStorage.getItem(STORAGE_KEY) || "",
+        imageUrl,
         boardWidth: boardW,
         boardHeight: boardH,
         grid,
@@ -104,6 +123,9 @@ export function PlayScreen() {
           popMapRef.current.set(p.id, performance.now());
         },
         onPuzzleComplete: () => {
+          // Clear saved state on completion
+          clearPuzzleState();
+
           import("canvas-confetti").then((confetti) => {
             confetti.default({
               particleCount: 150,
@@ -115,9 +137,29 @@ export function PlayScreen() {
       },
     );
 
+    // Restore piece positions if we have a saved game
+    if (hasSavedGame && savedState) {
+      next.restoreFromSaved(savedState.pieces);
+    }
+
     setManager(next);
     setState(next.getState());
   }, [grid]);
+
+  // Auto-save puzzle state when pieces change (debounced)
+  useEffect(() => {
+    if (!state || state.isComplete) return;
+
+    const imageUrl = localStorage.getItem(STORAGE_KEY) || "";
+    if (!imageUrl) return;
+
+    // Debounce saves to avoid excessive writes
+    const timeoutId = setTimeout(() => {
+      savePuzzleState(imageUrl, state.grid, state.pieces, elapsedSeconds);
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
+  }, [state, elapsedSeconds]);
 
   // Resize observer: keep canvas + manager board size synced
   useEffect(() => {
@@ -321,6 +363,13 @@ export function PlayScreen() {
     [manager],
   );
 
+  // Handle starting a new game (clears saved state and reloads)
+  const handleNewGame = useCallback(() => {
+    if (!confirm("Start a new game? Your current progress will be lost.")) return;
+    clearPuzzleState();
+    window.location.reload();
+  }, []);
+
   // Get tray pieces sorted by color
   const trayPieces = useMemo(() => {
     if (!state || !imgRef.current) return [];
@@ -377,6 +426,9 @@ export function PlayScreen() {
           }
         >
           Debug
+        </button>
+        <button className={styles.iconBtn} onClick={handleNewGame}>
+          New Game
         </button>
       </div>
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Description

**Save** and **restore** puzzle progress across browser sessions.

- Puzzle state auto-saves as you play (piece positions, groups, timer)
- Refreshing or closing the browser preserves your progress
- "New Game" button to start fresh
- Saved state clears automatically when you complete a puzzle

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

- [x] I have tested these changes locally
- [x] I have tested these changes in multiple browsers/environments if applicable

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings or errors
- [ ] I have updated documentation if needed

## How to Test

1. Start a puzzle and move some pieces around
2. Refresh the page - pieces should be in the same positions
3. Verify timer continues from where it left off
4. Open DevTools Console and run: `JSON.parse(localStorage.getItem('phuzzle:puzzleState'))` to see saved data
5. Click "New Game" - should confirm and reset
6. Complete a puzzle - next game should start fresh (saved state auto-clears)

## Screenshots (if applicable)

**N/A**

## Additional Notes

**N/A**
