### PR TITLE
Feature/39 post mvp add light animations and polish

### DIFF
--- a/src/app/components/PieceTray/PieceTray.module.css
+++ b/src/app/components/PieceTray/PieceTray.module.css
@@ -19,8 +19,9 @@
 }
 
 .trayHeader {
-  padding: 8px 12px;
+  padding: 10px 14px;
   font-weight: 600;
+  font-size: 15px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   background: rgba(0, 0, 0, 0.02);
   flex-shrink: 0;
@@ -31,7 +32,7 @@
 
 .trayHelp {
   font-weight: 400;
-  font-size: 11px;
+  font-size: 13px;
   color: rgba(0, 0, 0, 0.5);
 }
 

--- a/src/app/puzzle/PuzzleManager.ts
+++ b/src/app/puzzle/PuzzleManager.ts
@@ -321,14 +321,17 @@ export class PuzzleManager {
     const piece = this.findPiece(pieceId);
     if (!piece) return;
     if (this.groupIsPlaced(piece.groupId)) return;
+    if (piece.isPlaced) return; // Extra safety check
 
     const step = this.rotationStepDeg;
     const next = (piece.rotation + step) % 360;
+    const groupId = piece.groupId;
 
+    // Rotate ALL pieces in the group together
     this.state = {
       ...this.state,
       pieces: this.state.pieces.map((p) =>
-        p.id === pieceId ? { ...p, rotation: next } : p,
+        p.groupId === groupId ? { ...p, rotation: next } : p,
       ),
     };
 

--- a/src/app/puzzle/canvas/renderBoard.ts
+++ b/src/app/puzzle/canvas/renderBoard.ts
@@ -1,5 +1,5 @@
 // src/app/puzzle/canvas/renderBoard.ts
-import type { Piece, PuzzleState } from "@/puzzle/types";
+import type { Piece, PuzzleState, DragState } from "@/puzzle/types";
 
 export type PopMap = Map<string, number>;
 
@@ -7,6 +7,13 @@ export type DebugFlags = {
   showGrid: boolean;
   showBounds: boolean;
   showIds: boolean;
+};
+
+export type AnimationState = {
+  draggedGroupId: string | null;
+  hoveredPieceId: string | null;
+  isComplete: boolean;
+  completedAtMs: number | null;
 };
 
 /**
@@ -28,6 +35,8 @@ export function renderBoard(
   popMap: PopMap,
   nowMs: number,
   debug: DebugFlags,
+  dragState?: DragState,
+  animState?: AnimationState,
 ) {
   const canvas = ctx.canvas;
 
@@ -60,11 +69,22 @@ export function renderBoard(
   // Get grid from state
   const { cols, rows } = state.grid;
 
+  // Determine dragged group
+  const draggedGroupId = dragState?.activeId
+    ? (state.pieces.find((p) => p.id === dragState.activeId)?.groupId ?? null)
+    : null;
+
   // Draw order by z (lowest -> highest) - only pieces NOT in tray
   const pieces = [...state.pieces].filter((p) => !p.inTray).sort((a, b) => a.z - b.z);
 
   for (const p of pieces) {
-    drawPiece(ctx, p, img, cols, rows, popMap, nowMs, debug);
+    const isDragging = draggedGroupId !== null && p.groupId === draggedGroupId;
+    drawPiece(ctx, p, img, cols, rows, popMap, nowMs, debug, isDragging, animState);
+  }
+
+  // Completion glow effect
+  if (animState?.isComplete && animState.completedAtMs) {
+    drawCompletionGlow(ctx, cssW, cssH, nowMs - animState.completedAtMs);
   }
 }
 
@@ -77,10 +97,16 @@ function drawPiece(
   popMap: PopMap,
   nowMs: number,
   debug: DebugFlags,
+  isDragging: boolean,
+  animState?: AnimationState,
 ) {
   // Pop animation scale (draw-time)
   const start = popMap.get(p.id);
-  const scale = start ? snapPopScale(nowMs - start) : 1;
+  const popScale = start ? snapPopScale(nowMs - start) : 1;
+
+  // Drag animation: slightly larger when dragging
+  const dragScale = isDragging ? 1.03 : 1;
+  const scale = popScale * dragScale;
 
   // Build path (piece-local viewBox coordinates: 0..w,0..h)
   let path: Path2D | null = null;
@@ -96,6 +122,20 @@ function drawPiece(
   }
 
   ctx.save();
+
+  // Drop shadow for dragged pieces
+  if (isDragging) {
+    ctx.shadowColor = "rgba(0, 0, 0, 0.3)";
+    ctx.shadowBlur = 12;
+    ctx.shadowOffsetX = 4;
+    ctx.shadowOffsetY = 4;
+  } else if (!p.isPlaced) {
+    // Subtle shadow for unplaced pieces
+    ctx.shadowColor = "rgba(0, 0, 0, 0.15)";
+    ctx.shadowBlur = 4;
+    ctx.shadowOffsetX = 2;
+    ctx.shadowOffsetY = 2;
+  }
 
   // Centered rotation + scale around piece center
   ctx.translate(p.x + p.w / 2, p.y + p.h / 2);
@@ -157,9 +197,23 @@ function drawPiece(
 
   ctx.restore();
 
-  // Outline
-  ctx.strokeStyle = "rgba(0,0,0,0.25)";
-  ctx.lineWidth = 1;
+  // Reset shadow before drawing outline
+  ctx.shadowColor = "transparent";
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 0;
+
+  // Outline - thicker for dragged pieces
+  if (isDragging) {
+    ctx.strokeStyle = "rgba(102, 126, 234, 0.6)";
+    ctx.lineWidth = 2;
+  } else if (p.isPlaced) {
+    ctx.strokeStyle = "rgba(0, 160, 80, 0.3)";
+    ctx.lineWidth = 1;
+  } else {
+    ctx.strokeStyle = "rgba(0,0,0,0.25)";
+    ctx.lineWidth = 1;
+  }
   ctx.stroke(path);
 
   if (debug.showBounds) {
@@ -178,17 +232,66 @@ function drawPiece(
 }
 
 function snapPopScale(tMs: number) {
-  // Quick up then back
+  // Quick up then back - satisfying snap feel
   if (tMs <= 0) return 1;
-  if (tMs >= 170) return 1;
+  if (tMs >= 200) return 1;
 
-  if (tMs < 90) {
-    const k = tMs / 90; // 0..1
-    return 1 + 0.08 * k;
+  if (tMs < 80) {
+    // Quick scale up
+    const k = tMs / 80;
+    return 1 + 0.1 * easeOutBack(k);
   }
 
-  const k = (tMs - 90) / 80; // 0..1
-  return 1.08 - 0.08 * k;
+  // Settle back down
+  const k = (tMs - 80) / 120;
+  return 1.1 - 0.1 * easeOutBounce(k);
+}
+
+// Easing functions for smooth animations
+function easeOutBack(t: number): number {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+}
+
+function easeOutBounce(t: number): number {
+  if (t < 0.5) {
+    return 2 * t * t;
+  }
+  return 1 - 2 * (1 - t) * (1 - t);
+}
+
+function drawCompletionGlow(
+  ctx: CanvasRenderingContext2D,
+  cssW: number,
+  cssH: number,
+  elapsedMs: number,
+) {
+  // Subtle pulsing glow that fades out after a few seconds
+  if (elapsedMs > 3000) return;
+
+  const fadeOut = Math.max(0, 1 - elapsedMs / 3000);
+  const pulse = 0.5 + 0.5 * Math.sin(elapsedMs / 200);
+  const alpha = 0.08 * fadeOut * pulse;
+
+  ctx.save();
+
+  // Golden glow overlay
+  const gradient = ctx.createRadialGradient(
+    cssW / 2,
+    cssH / 2,
+    0,
+    cssW / 2,
+    cssH / 2,
+    Math.max(cssW, cssH) / 2,
+  );
+  gradient.addColorStop(0, `rgba(255, 215, 0, ${alpha})`);
+  gradient.addColorStop(1, `rgba(255, 215, 0, 0)`);
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, cssW, cssH);
+
+  ctx.restore();
 }
 
 function drawDebugBackdrop(ctx: CanvasRenderingContext2D, cssW: number, cssH: number) {

--- a/src/app/puzzle/canvas/renderBoard.ts
+++ b/src/app/puzzle/canvas/renderBoard.ts
@@ -71,7 +71,7 @@ export function renderBoard(
 
   // Determine dragged group
   const draggedGroupId = dragState?.activeId
-    ? state.pieces.find((p) => p.id === dragState.activeId)?.groupId ?? null
+    ? (state.pieces.find((p) => p.id === dragState.activeId)?.groupId ?? null)
     : null;
 
   // Draw order by z (lowest -> highest) - only pieces NOT in tray
@@ -103,7 +103,7 @@ function drawPiece(
   // Pop animation scale (draw-time)
   const start = popMap.get(p.id);
   const popScale = start ? snapPopScale(nowMs - start) : 1;
-  
+
   // Drag animation: slightly larger when dragging
   const dragScale = isDragging ? 1.03 : 1;
   const scale = popScale * dragScale;
@@ -194,7 +194,7 @@ function drawPiece(
   // Draw the entire source image, scaled and positioned
   // The clip path will cut it to the jigsaw shape
   ctx.drawImage(img, imgX, imgY, imgW, imgH);
-  
+
   ctx.restore();
 
   // Reset shadow before drawing outline
@@ -275,18 +275,22 @@ function drawCompletionGlow(
   const alpha = 0.08 * fadeOut * pulse;
 
   ctx.save();
-  
+
   // Golden glow overlay
   const gradient = ctx.createRadialGradient(
-    cssW / 2, cssH / 2, 0,
-    cssW / 2, cssH / 2, Math.max(cssW, cssH) / 2
+    cssW / 2,
+    cssH / 2,
+    0,
+    cssW / 2,
+    cssH / 2,
+    Math.max(cssW, cssH) / 2,
   );
   gradient.addColorStop(0, `rgba(255, 215, 0, ${alpha})`);
   gradient.addColorStop(1, `rgba(255, 215, 0, 0)`);
-  
+
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, cssW, cssH);
-  
+
   ctx.restore();
 }
 

--- a/src/app/puzzle/canvas/renderBoard.ts
+++ b/src/app/puzzle/canvas/renderBoard.ts
@@ -71,7 +71,7 @@ export function renderBoard(
 
   // Determine dragged group
   const draggedGroupId = dragState?.activeId
-    ? (state.pieces.find((p) => p.id === dragState.activeId)?.groupId ?? null)
+    ? state.pieces.find((p) => p.id === dragState.activeId)?.groupId ?? null
     : null;
 
   // Draw order by z (lowest -> highest) - only pieces NOT in tray
@@ -98,12 +98,12 @@ function drawPiece(
   nowMs: number,
   debug: DebugFlags,
   isDragging: boolean,
-  animState?: AnimationState,
+  _animState?: AnimationState,
 ) {
   // Pop animation scale (draw-time)
   const start = popMap.get(p.id);
   const popScale = start ? snapPopScale(nowMs - start) : 1;
-
+  
   // Drag animation: slightly larger when dragging
   const dragScale = isDragging ? 1.03 : 1;
   const scale = popScale * dragScale;
@@ -194,7 +194,7 @@ function drawPiece(
   // Draw the entire source image, scaled and positioned
   // The clip path will cut it to the jigsaw shape
   ctx.drawImage(img, imgX, imgY, imgW, imgH);
-
+  
   ctx.restore();
 
   // Reset shadow before drawing outline
@@ -275,22 +275,18 @@ function drawCompletionGlow(
   const alpha = 0.08 * fadeOut * pulse;
 
   ctx.save();
-
+  
   // Golden glow overlay
   const gradient = ctx.createRadialGradient(
-    cssW / 2,
-    cssH / 2,
-    0,
-    cssW / 2,
-    cssH / 2,
-    Math.max(cssW, cssH) / 2,
+    cssW / 2, cssH / 2, 0,
+    cssW / 2, cssH / 2, Math.max(cssW, cssH) / 2
   );
   gradient.addColorStop(0, `rgba(255, 215, 0, ${alpha})`);
   gradient.addColorStop(1, `rgba(255, 215, 0, 0)`);
-
+  
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, cssW, cssH);
-
+  
   ctx.restore();
 }
 

--- a/src/app/screens/Play/PlayScreen.tsx
+++ b/src/app/screens/Play/PlayScreen.tsx
@@ -56,6 +56,9 @@ export function PlayScreen() {
   // Preview image visibility
   const [showPreview, setShowPreview] = useState(false);
 
+  // Track completion time for animation
+  const completedAtRef = useRef<number | null>(null);
+
   // Grid from localStorage
   const grid = useMemo(() => parseGrid(localStorage.getItem(GRID_KEY)), []);
 
@@ -234,6 +237,13 @@ export function PlayScreen() {
       const assembledW = st.grid.cols * firstPiece.tileW;
       const assembledH = st.grid.rows * firstPiece.tileH;
 
+      // Track completion time for glow animation
+      if (st.isComplete && !completedAtRef.current) {
+        completedAtRef.current = performance.now();
+      } else if (!st.isComplete) {
+        completedAtRef.current = null;
+      }
+
       renderBoard(
         ctx,
         st,
@@ -243,6 +253,13 @@ export function PlayScreen() {
         popMapRef.current,
         performance.now(),
         debug,
+        manager.getDragState(),
+        {
+          draggedGroupId: null,
+          hoveredPieceId: null,
+          isComplete: st.isComplete,
+          completedAtMs: completedAtRef.current,
+        },
       );
 
       // keep react state reasonably fresh
@@ -371,9 +388,9 @@ export function PlayScreen() {
     [manager],
   );
 
-  // Handle starting a new game (clears saved state and reloads)
+  // Handle starting a new puzzle (clears saved state and reloads)
   const handleNewGame = useCallback(() => {
-    if (!confirm("Start a new game? Your current progress will be lost.")) return;
+    if (!confirm("Start a new puzzle? Your current progress will be lost.")) return;
     clearPuzzleState();
     window.location.reload();
   }, []);
@@ -441,7 +458,7 @@ export function PlayScreen() {
           </button>
         )}
         <button className={styles.iconBtn} onClick={handleNewGame}>
-          New Game
+          Start New Puzzle
         </button>
       </div>
 

--- a/src/app/screens/Setup/SetupScreen.module.css
+++ b/src/app/screens/Setup/SetupScreen.module.css
@@ -201,15 +201,19 @@
 
 /* Gallery grid */
 .gallery {
+  --thumb: 108px; /* tweak 96–120 to taste */
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--thumb), 1fr));
+  grid-auto-rows: var(--thumb); /* KEY: rows get a real height */
   gap: 12px;
   max-height: 240px;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 8px;
   background: rgba(255, 255, 255, 0.5);
   border-radius: 12px;
   border: 1px solid rgba(11, 99, 184, 0.15);
+  align-content: start; /* don’t stretch rows weirdly */
 }
 
 .galleryEmpty {
@@ -221,7 +225,8 @@
 }
 
 .galleryItem {
-  aspect-ratio: 1;
+  width: 100%;
+  height: 100%; /* KEY: fill the grid cell */
   border: 3px solid transparent;
   border-radius: 12px;
   overflow: hidden;
@@ -229,14 +234,16 @@
   background: white;
   padding: 0;
   position: relative;
+  display: block; /* keep it simple */
   transition: all 0.2s;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  min-width: 0; /* helps inside grid */
 }
 
 .galleryItem:hover {
   border-color: rgba(11, 99, 184, 0.5);
-  transform: scale(1.05);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: scale(1.03); /* slightly less aggressive */
+  z-index: 2; /* sit above neighbors */
 }
 
 .galleryItem:disabled {
@@ -252,6 +259,7 @@
 .galleryItem img {
   width: 100%;
   height: 100%;
+  display: block; /* kills baseline gaps */
   object-fit: cover;
 }
 


### PR DESCRIPTION
## Description

Add subtle animations and visual polish for a more satisfying puzzle experience.
Changes:

- Pieces scale up slightly (1.03x) and cast deeper shadow when dragged
- Improved snap animation with easeOutBack/Bounce easing for satisfying "pop"
- Different outline colors: blue (dragging), green (placed), subtle black (normal)
- Subtle golden glow pulse on puzzle completion (fades after 3 seconds)
- Increased Piece Drawer text size for better readability

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

- [x] I have tested these changes locally
- [x ] I have tested these changes in multiple browsers/environments if applicable

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if needed

## How to Test

1. Start a new puzzle
2. Drag effect: Pick up a piece - verify it scales up slightly and casts a shadow
3. Drop effect: Release the piece - verify shadow returns to subtle
4. Snap animation: Connect two pieces - verify satisfying bounce/pop animation
5. Placed outline: Complete a section - verify placed pieces have subtle green outline
6. Completion glow: Finish the puzzle - verify subtle golden glow pulses then fades
7. Piece Drawer: Verify "Piece Drawer" and help text are readable (larger than before)
8. Verify all animations feel smooth and subtle, not distracting

## Screenshots (if applicable)

**N/A**

## Additional Notes

**N/A**
