### PR TITLE
Feature/98 piece locking toggle

### DIFF
--- a/src/app/puzzle/PuzzleManager.ts
+++ b/src/app/puzzle/PuzzleManager.ts
@@ -41,6 +41,9 @@ export class PuzzleManager {
   private scatterStartYRatio: number;
   private rotationStepDeg: 90 | 180;
 
+  /** When true, pieces that snap to correct position become locked (cannot be moved). */
+  private pieceLockingEnabled: boolean = false;
+
   private pad: number;
   private tileW: number;
   private tileH: number;
@@ -292,6 +295,14 @@ export class PuzzleManager {
     return this.state;
   }
 
+  setPieceLockingEnabled(enabled: boolean): void {
+    this.pieceLockingEnabled = enabled;
+  }
+
+  getPieceLockingEnabled(): boolean {
+    return this.pieceLockingEnabled;
+  }
+
   getDragState(): DragState {
     return this.drag;
   }
@@ -302,20 +313,20 @@ export class PuzzleManager {
 
   public nudgeGroup(pieceId: string, dx: number, dy: number) {
     const p = this.findPiece(pieceId);
-    if (!p || p.isPlaced) return;
+    if (!p || p.isPlaced || p.locked) return;
     this.shiftGroup(p.groupId, dx, dy);
     this.recomputeDerivedState();
   }
 
   public rotateGroup(pieceId: string) {
     const p = this.findPiece(pieceId);
-    if (!p || p.isPlaced) return;
+    if (!p || p.isPlaced || p.locked) return;
     this.rotatePiece(pieceId);
   }
 
   public rotatePiece(pieceId: string) {
     const piece = this.findPiece(pieceId);
-    if (!piece || piece.isPlaced) return;
+    if (!piece || piece.isPlaced || piece.locked) return;
 
     // Rotate all pieces in the group
     this.state = {
@@ -332,11 +343,11 @@ export class PuzzleManager {
 
   public snapGroupNow(pieceId: string) {
     const p = this.findPiece(pieceId);
-    if (!p || p.isPlaced) return;
+    if (!p || p.isPlaced || p.locked) return;
 
     this.drag = { ...this.drag, activeId: p.id };
-    this.trySnapActiveGroupToBoard();
     this.trySnapActiveGroupToNeighbor();
+    this.trySnapActiveGroupToBoard();
     this.drag = { activeId: null, offsetX: 0, offsetY: 0, preview: null };
     this.recomputeDerivedState();
   }
@@ -348,7 +359,7 @@ export class PuzzleManager {
 
   movePieceToTray(pieceId: string) {
     const piece = this.findPiece(pieceId);
-    if (!piece || piece.isPlaced) return;
+    if (!piece || piece.isPlaced || piece.locked) return;
 
     const groupPieces = this.getGroupPieces(piece.groupId);
     if (groupPieces.length > 1) return;
@@ -411,7 +422,7 @@ export class PuzzleManager {
     pieceRect: DOMRect,
   ) {
     const piece = this.findPiece(pieceId);
-    if (!piece || piece.isPlaced) return;
+    if (!piece || piece.isPlaced || piece.locked) return;
 
     // Bring group to front
     this.zCounter += 1;
@@ -464,9 +475,10 @@ export class PuzzleManager {
   public pointerUp() {
     if (!this.drag.activeId) return;
 
-    // Try to snap
-    this.trySnapActiveGroupToBoard();
+    // Try neighbor snap first (connect pieces), then board snap (align to grid).
+    // Order matters: board-then-neighbor could undo the board snap by aligning to a floating neighbor.
     this.trySnapActiveGroupToNeighbor();
+    this.trySnapActiveGroupToBoard();
 
     // Clear drag state
     this.drag = {
@@ -496,6 +508,7 @@ export class PuzzleManager {
             rotation: saved.rotation,
             groupId: saved.groupId,
             isPlaced: saved.isPlaced,
+            locked: saved.locked ?? false,
             inTray: saved.inTray,
           };
         }
@@ -531,10 +544,13 @@ export class PuzzleManager {
 
     // Mark as snapped for visual feedback, but don't set isPlaced
     // (isPlaced is only set when entire puzzle is complete)
+    // When piece locking is enabled, lock all pieces in the snapped group
     this.state = {
       ...this.state,
       pieces: this.state.pieces.map((p) =>
-        p.groupId === gid ? { ...p, justSnapped: true } : p,
+        p.groupId === gid
+          ? { ...p, justSnapped: true, locked: this.pieceLockingEnabled || p.locked }
+          : p,
       ),
     };
     this.events.onPiecePlaced?.(active);
@@ -579,6 +595,16 @@ export class PuzzleManager {
 
     this.shiftGroupUnclamped(gid, Math.round(best.dx), Math.round(best.dy));
     this.mergeGroups(gid, best.into);
+
+    // When piece locking is enabled, lock all pieces in the merged group
+    if (this.pieceLockingEnabled) {
+      this.state = {
+        ...this.state,
+        pieces: this.state.pieces.map((p) =>
+          p.groupId === best.into ? { ...p, locked: true } : p,
+        ),
+      };
+    }
 
     this.trySnapMergedGroupToBoard(best.into);
     this.events.onPieceSnapped?.();

--- a/src/app/puzzle/canvas/renderBoard.ts
+++ b/src/app/puzzle/canvas/renderBoard.ts
@@ -213,6 +213,9 @@ function drawPiece(
   } else if (p.isPlaced) {
     ctx.strokeStyle = "rgba(0, 160, 80, 0.3)";
     ctx.lineWidth = 1;
+  } else if (p.locked) {
+    ctx.strokeStyle = "rgba(0, 160, 80, 0.4)";
+    ctx.lineWidth = 1.5;
   } else {
     ctx.strokeStyle = "rgba(0,0,0,0.25)";
     ctx.lineWidth = 1;

--- a/src/app/puzzle/factories/createInitialPieces.ts
+++ b/src/app/puzzle/factories/createInitialPieces.ts
@@ -165,6 +165,7 @@ export function createInitialPieces(args: CreateInitialPiecesArgs): Piece[] {
       rotation: randRotation(rotationStepDeg),
       targetRotation: 0,
       isPlaced: false,
+      locked: false,
       groupId: `g${i + 1}`,
       justSnapped: false,
       shapePath,

--- a/src/app/puzzle/puzzleStorage.ts
+++ b/src/app/puzzle/puzzleStorage.ts
@@ -17,6 +17,7 @@ export type SavedPiece = {
   z: number;
   rotation: number;
   isPlaced: boolean;
+  locked: boolean;
   groupId: string;
   inTray: boolean;
 };
@@ -48,6 +49,7 @@ export function savePuzzleState(
     z: p.z,
     rotation: p.rotation,
     isPlaced: p.isPlaced,
+    locked: p.locked,
     groupId: p.groupId,
     inTray: p.inTray,
   }));

--- a/src/app/puzzle/types.ts
+++ b/src/app/puzzle/types.ts
@@ -71,6 +71,12 @@ export type Piece = {
   isPlaced: boolean;
 
   /**
+   * When piece locking is enabled, pieces that snap to correct position are locked.
+   * Locked pieces cannot be dragged, rotated, or sent to tray.
+   */
+  locked: boolean;
+
+  /**
    * Group id for clusters. Pieces in same group move together.
    * Neighbor snap merges groups.
    */

--- a/src/app/screens/Play/PlayScreen.tsx
+++ b/src/app/screens/Play/PlayScreen.tsx
@@ -32,6 +32,7 @@ import {
 
 const STORAGE_KEY = "phuzzle:imageDataUrl";
 const GRID_KEY = "phuzzle:gridSize";
+const PIECE_LOCKING_KEY = "phuzzle:pieceLocking";
 
 // Debug mode from environment variable
 const SHOW_DEBUG = import.meta.env.VITE_SHOW_DEBUG === "true";
@@ -88,6 +89,15 @@ export function PlayScreen() {
 
   // Shortcuts help modal
   const [showShortcuts, setShowShortcuts] = useState(false);
+
+  // Piece locking: when enabled, snapped pieces become locked (cannot be moved)
+  const [pieceLockingEnabled, setPieceLockingEnabled] = useState(() => {
+    try {
+      return localStorage.getItem(PIECE_LOCKING_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
 
   // Modal state for new game confirmation
   const [showNewGameModal, setShowNewGameModal] = useState(false);
@@ -206,14 +216,16 @@ export function PlayScreen() {
         }
         case "rotateCW":
         case "rotateCCW":
-          // Rotate the selected piece (or first unplaced if none selected)
+          // Rotate the selected piece (or first movable if none selected)
           if (manager && state && !isPaused) {
-            const unplacedPieces = state.pieces.filter((p) => !p.isPlaced && !p.inTray);
-            let pieceToRotate = unplacedPieces.find((p) => p.id === selectedPieceId);
+            const movablePieces = state.pieces.filter(
+              (p) => !p.isPlaced && !p.inTray && !p.locked,
+            );
+            let pieceToRotate = movablePieces.find((p) => p.id === selectedPieceId);
 
-            // If selected piece is placed or not found, use first unplaced
-            if (!pieceToRotate && unplacedPieces.length > 0) {
-              pieceToRotate = unplacedPieces[0];
+            // If selected piece is placed/locked or not found, use first movable
+            if (!pieceToRotate && movablePieces.length > 0) {
+              pieceToRotate = movablePieces[0];
               setSelectedPieceId(pieceToRotate.id);
             }
 
@@ -226,27 +238,29 @@ export function PlayScreen() {
           break;
         case "nextPiece":
         case "prevPiece": {
-          // Tab through unplaced pieces
+          // Tab through movable pieces (not placed, not in tray, not locked)
           if (state && !isPaused) {
-            const unplacedPieces = state.pieces.filter((p) => !p.isPlaced && !p.inTray);
-            if (unplacedPieces.length === 0) break;
+            const movablePieces = state.pieces.filter(
+              (p) => !p.isPlaced && !p.inTray && !p.locked,
+            );
+            if (movablePieces.length === 0) break;
 
-            const currentIndex = unplacedPieces.findIndex(
+            const currentIndex = movablePieces.findIndex(
               (p) => p.id === selectedPieceId,
             );
             let newIndex: number;
 
             if (action === "nextPiece") {
               newIndex =
-                currentIndex < 0 ? 0 : (currentIndex + 1) % unplacedPieces.length;
+                currentIndex < 0 ? 0 : (currentIndex + 1) % movablePieces.length;
             } else {
               newIndex =
                 currentIndex < 0
-                  ? unplacedPieces.length - 1
-                  : (currentIndex - 1 + unplacedPieces.length) % unplacedPieces.length;
+                  ? movablePieces.length - 1
+                  : (currentIndex - 1 + movablePieces.length) % movablePieces.length;
             }
 
-            setSelectedPieceId(unplacedPieces[newIndex].id);
+            setSelectedPieceId(movablePieces[newIndex].id);
           }
           break;
         }
@@ -257,7 +271,7 @@ export function PlayScreen() {
           // Move selected piece with arrow keys
           if (manager && state && !isPaused && selectedPieceId) {
             const piece = state.pieces.find((p) => p.id === selectedPieceId);
-            if (piece && !piece.isPlaced && !piece.inTray) {
+            if (piece && !piece.isPlaced && !piece.inTray && !piece.locked) {
               const moveAmount = 20; // pixels per keypress
               let dx = 0,
                 dy = 0;
@@ -360,15 +374,30 @@ export function PlayScreen() {
       next.restoreFromSaved(savedState.pieces);
     }
 
+    next.setPieceLockingEnabled(pieceLockingEnabled);
     setManager(next);
     const st = next.getState();
     setState(st);
 
-    // Set an initial selection if possible
-    const selectable = st.pieces.filter((p) => !p.inTray && !p.isPlaced);
+    // Set an initial selection if possible (prefer movable pieces)
+    const selectable = st.pieces.filter((p) => !p.inTray && !p.isPlaced && !p.locked);
     selectedIdRef.current = selectable.length ? selectable[0].id : null;
     bump();
   }, [grid]);
+
+  // Sync piece locking to manager when it changes (manager may be recreated with grid)
+  useEffect(() => {
+    manager?.setPieceLockingEnabled(pieceLockingEnabled);
+  }, [manager, pieceLockingEnabled]);
+
+  // Persist piece locking preference
+  useEffect(() => {
+    try {
+      localStorage.setItem(PIECE_LOCKING_KEY, pieceLockingEnabled ? "true" : "false");
+    } catch {
+      // ignore
+    }
+  }, [pieceLockingEnabled]);
 
   // Auto-save puzzle state when pieces change (debounced)
   useEffect(() => {
@@ -740,6 +769,7 @@ export function PlayScreen() {
             showPreview={showPreview}
             soundEnabled={soundEnabled}
             hapticsEnabled={hapticsEnabled}
+            pieceLockingEnabled={pieceLockingEnabled}
             isFullscreen={isFullscreen}
             canShowHaptics={
               isCoarsePointer &&
@@ -765,6 +795,7 @@ export function PlayScreen() {
                 navigator.vibrate(25);
               }
             }}
+            onTogglePieceLocking={() => setPieceLockingEnabled((p) => !p)}
             onToggleFullscreen={toggleFullscreen}
             onShowShortcuts={() => setShowShortcuts(true)}
             onToggleDebug={() =>

--- a/src/app/screens/Play/PlayScreen.tsx
+++ b/src/app/screens/Play/PlayScreen.tsx
@@ -245,14 +245,11 @@ export function PlayScreen() {
             );
             if (movablePieces.length === 0) break;
 
-            const currentIndex = movablePieces.findIndex(
-              (p) => p.id === selectedPieceId,
-            );
+            const currentIndex = movablePieces.findIndex((p) => p.id === selectedPieceId);
             let newIndex: number;
 
             if (action === "nextPiece") {
-              newIndex =
-                currentIndex < 0 ? 0 : (currentIndex + 1) % movablePieces.length;
+              newIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % movablePieces.length;
             } else {
               newIndex =
                 currentIndex < 0

--- a/src/app/screens/Play/components/HeaderMenu.tsx
+++ b/src/app/screens/Play/components/HeaderMenu.tsx
@@ -17,6 +17,7 @@ export type HeaderMenuProps = {
   showPreview: boolean;
   soundEnabled: boolean;
   hapticsEnabled: boolean;
+  pieceLockingEnabled: boolean;
   isFullscreen: boolean;
 
   canShowHaptics: boolean;
@@ -30,6 +31,7 @@ export type HeaderMenuProps = {
   onTogglePreview: () => void;
   onToggleSound: () => void;
   onToggleHaptics: () => void;
+  onTogglePieceLocking: () => void;
   onToggleFullscreen: () => void;
   onShowShortcuts: () => void;
   onToggleDebug: () => void;
@@ -135,6 +137,17 @@ export function HeaderMenu(props: HeaderMenuProps) {
           >
             <ThemeToggle variant="menuItem" />
           </div>
+
+          <button
+            className={styles.headerMenuItem}
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              props.onTogglePieceLocking();
+            }}
+          >
+            {props.pieceLockingEnabled ? "Lock pieces: on" : "Lock pieces: off"}
+          </button>
 
           {props.canShowHaptics && (
             <button

--- a/src/app/screens/Play/hooks/usePointerHandlers.ts
+++ b/src/app/screens/Play/hooks/usePointerHandlers.ts
@@ -57,6 +57,9 @@ export function usePointerHandlers(args: {
       // Hard lock: placed pieces never rotate
       if (piece.isPlaced) return false;
 
+      // User lock: locked pieces cannot be rotated
+      if (piece.locked) return false;
+
       // Pieces in tray should not rotate from board interactions
       if (piece.inTray) return false;
 
@@ -108,6 +111,10 @@ export function usePointerHandlers(args: {
       const boardPieces = st.pieces.filter((p) => !p.inTray);
       const pieceId = pickPieceId(ctx, boardPieces, cssX, cssY);
       if (!pieceId) return;
+
+      // Locked pieces cannot be interacted with (no select, drag, or long-press)
+      const piece = st.pieces.find((p) => p.id === pieceId);
+      if (piece?.locked) return;
 
       // Select what we clicked
       selectedIdRef.current = pieceId;


### PR DESCRIPTION
## Description

This makes it so once pieces are locked you can not move them

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement

## Testing

- [x] I have tested these changes locally
- [x] I have tested these changes in multiple browsers/environments if applicable

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if needed

## How to Test

1. Check out my branch
2. Run `npm i`
3. Run `npm build`
4. Run `npm run dev:host`
5. Test this on mobile and desktop
6. Move pieces see they lock and then do not move

## Screenshots (if applicable)

**N/A**

## Additional Notes

**N/A**