### PR TITLE
Adding in changes to make touch zoom work on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A calm, cozy puzzle you can open anytime — part mindfulness, part challenge.
 - Multiple difficulty levels (3×3 to 6×6 grids, custom sizes)
 - Image sources: gallery, file upload, or camera capture
 - Edge-piece tray filter — All, Edges, Corners, Center (Grid/Color sort)
-- Zoom and pan — scroll to zoom (toward cursor), middle-click drag to pan; on mobile: two-finger pinch and drag
+- Zoom and pan — scroll to zoom (toward cursor), middle-click drag to pan; on mobile: two-finger pinch/drag, single-finger drag on empty space when zoomed
 
 ### UX & Polish
 
@@ -87,7 +87,8 @@ A calm, cozy puzzle you can open anytime — part mindfulness, part challenge.
 ### Mobile Support
 
 - Touch drag, tap to rotate, drag pieces to tray
-- Two-finger pinch to zoom, two-finger drag to pan (iOS & Android)
+- Two-finger pinch to zoom, two-finger drag to pan (iOS & Android, touch-event-based for reliability)
+- Single-finger pan when zoomed — drag on empty space to pan
 - Haptic feedback
 - Camera capture for instant puzzles
 - Mobile-safe layouts and gestures (44px touch targets)
@@ -110,6 +111,7 @@ A calm, cozy puzzle you can open anytime — part mindfulness, part challenge.
 - **Help modal** — Main menu and play screen: "Help" opens How to Play + Keyboard shortcuts (all devices)
 - Keyboard shortcuts (Tab, arrows, R to rotate, ? or F1 for help, Ctrl+Z/Y undo/redo)
 - First-time tutorial overlay
+- Settings sub-menus — Game (time, ghost, lock), View (theme, preview, fullscreen), Audio (sound, haptics)
 - Undo · Redo · Ghost hint · Lock pieces (optional)
 - Designed for relaxed, low-pressure play
 
@@ -125,14 +127,14 @@ A calm, cozy puzzle you can open anytime — part mindfulness, part challenge.
 
 ### Completed ✓
 
-| Area        | Features                                                                                                                                                                   |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Core**    | Dark mode · Undo · Redo · Ghost hint · Lock pieces · Share image · Edge-piece tray filter · Zoom & pan                                                                     |
-| **Time**    | Elapsed, countdown, active-only, relaxed, best time                                                                                                                        |
-| **Daily**   | Same puzzle for everyone · Streak tracking                                                                                                                                 |
-| **Social**  | Stats · Leaderboards · Profile (display name, anonymous) · Achievements                                                                                                    |
-| **Content** | What's New popup · Camera capture · Sample puzzle gallery                                                                                                                  |
-| **UX**      | Help modal (How to Play + Keyboard shortcuts) · Theme as action card · Difficulty emojis · Mobile piece scaling · Tray start (16+) · Two-finger pinch zoom (iOS & Android) |
+| Area        | Features                                                                                                                                                                                                                                            |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Core**    | Dark mode · Undo · Redo · Ghost hint · Lock pieces · Share image · Edge-piece tray filter · Zoom & pan                                                                                                                                              |
+| **Time**    | Elapsed, countdown, active-only, relaxed, best time                                                                                                                                                                                                 |
+| **Daily**   | Same puzzle for everyone · Streak tracking                                                                                                                                                                                                          |
+| **Social**  | Stats · Leaderboards · Profile (display name, anonymous) · Achievements                                                                                                                                                                             |
+| **Content** | What's New popup · Camera capture · Sample puzzle gallery                                                                                                                                                                                           |
+| **UX**      | Help modal (How to Play + Keyboard shortcuts) · Theme as action card · Difficulty emojis · Mobile piece scaling · Tray start (16+) · Two-finger pinch zoom (iOS & Android) · Single-finger pan when zoomed · Settings sub-menus (Game, View, Audio) |
 
 ### Planned
 
@@ -190,15 +192,15 @@ Category = folder name, puzzle name = filename.
 
 ## Project Structure
 
-| Folder                        | Purpose                                                                                |
-| ----------------------------- | -------------------------------------------------------------------------------------- |
-| `src/app/puzzle/`             | Core puzzle logic: PuzzleManager, pieces, canvas rendering, undo, storage              |
-| `src/app/screens/`            | Screen components: Menu, NewGame, Setup, Play, Stats                                   |
-| `src/app/screens/Play/hooks/` | Play screen hooks: manager, animation, timer, pointer handlers, viewport               |
-| `src/app/components/`         | Shared UI: Modal, Button, PieceTray, HelpChoiceModal, ThemeModal, ShortcutsModal, etc. |
-| `src/app/audio/`              | Sound effects                                                                          |
-| `src/app/services/`           | Supabase: stats, leaderboard, profile, achievements                                    |
-| `src/app/assets/puzzles/`     | Sample puzzle images by category                                                       |
+| Folder                        | Purpose                                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------------------- |
+| `src/app/puzzle/`             | Core puzzle logic: PuzzleManager, pieces, canvas rendering, undo, storage                           |
+| `src/app/screens/`            | Screen components: Menu, NewGame, Setup, Play, Stats                                                |
+| `src/app/screens/Play/hooks/` | Play screen hooks: manager, animation, timer, pointer handlers (touch + mouse), viewport (zoom/pan) |
+| `src/app/components/`         | Shared UI: Modal, Button, PieceTray, HelpChoiceModal, ThemeModal, ShortcutsModal, etc.              |
+| `src/app/audio/`              | Sound effects                                                                                       |
+| `src/app/services/`           | Supabase: stats, leaderboard, profile, achievements                                                 |
+| `src/app/assets/puzzles/`     | Sample puzzle images by category                                                                    |
 
 <details>
 <summary>📁 Click to expand file structure</summary>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A calm, cozy puzzle you can open anytime — part mindfulness, part challenge.
 - Multiple difficulty levels (3×3 to 6×6 grids, custom sizes)
 - Image sources: gallery, file upload, or camera capture
 - Edge-piece tray filter — All, Edges, Corners, Center (Grid/Color sort)
-- Zoom and pan — scroll to zoom (toward cursor), middle-click drag to pan
+- Zoom and pan — scroll to zoom (toward cursor), middle-click drag to pan; on mobile: two-finger pinch and drag
 
 ### UX & Polish
 
@@ -87,6 +87,7 @@ A calm, cozy puzzle you can open anytime — part mindfulness, part challenge.
 ### Mobile Support
 
 - Touch drag, tap to rotate, drag pieces to tray
+- Two-finger pinch to zoom, two-finger drag to pan (iOS & Android)
 - Haptic feedback
 - Camera capture for instant puzzles
 - Mobile-safe layouts and gestures (44px touch targets)
@@ -124,14 +125,14 @@ A calm, cozy puzzle you can open anytime — part mindfulness, part challenge.
 
 ### Completed ✓
 
-| Area        | Features                                                                                                                           |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| **Core**    | Dark mode · Undo · Redo · Ghost hint · Lock pieces · Share image · Edge-piece tray filter · Zoom & pan                             |
-| **Time**    | Elapsed, countdown, active-only, relaxed, best time                                                                                |
-| **Daily**   | Same puzzle for everyone · Streak tracking                                                                                         |
-| **Social**  | Stats · Leaderboards · Profile (display name, anonymous) · Achievements                                                            |
-| **Content** | What's New popup · Camera capture · Sample puzzle gallery                                                                          |
-| **UX**      | Help modal (How to Play + Keyboard shortcuts) · Theme as action card · Difficulty emojis · Mobile piece scaling · Tray start (16+) |
+| Area        | Features                                                                                                                                                                   |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Core**    | Dark mode · Undo · Redo · Ghost hint · Lock pieces · Share image · Edge-piece tray filter · Zoom & pan                                                                     |
+| **Time**    | Elapsed, countdown, active-only, relaxed, best time                                                                                                                        |
+| **Daily**   | Same puzzle for everyone · Streak tracking                                                                                                                                 |
+| **Social**  | Stats · Leaderboards · Profile (display name, anonymous) · Achievements                                                                                                    |
+| **Content** | What's New popup · Camera capture · Sample puzzle gallery                                                                                                                  |
+| **UX**      | Help modal (How to Play + Keyboard shortcuts) · Theme as action card · Difficulty emojis · Mobile piece scaling · Tray start (16+) · Two-finger pinch zoom (iOS & Android) |
 
 ### Planned
 

--- a/src/app/components/HowToPlay/TutorialOverlay.tsx
+++ b/src/app/components/HowToPlay/TutorialOverlay.tsx
@@ -90,6 +90,16 @@ export function TutorialOverlay({
           </p>
         </div>
 
+        {isTouch && (
+          <div className={styles.section}>
+            <h3 className={styles.sectionTitle}>📱 Zoom & Pan</h3>
+            <p>
+              Pinch with two fingers to zoom in or out on the board. Drag with two fingers
+              to pan around. Great for larger puzzles!
+            </p>
+          </div>
+        )}
+
         <div className={styles.section}>
           <h3 className={styles.sectionTitle}>⏱ Time Modes</h3>
           <p>

--- a/src/app/components/HowToPlay/TutorialOverlay.tsx
+++ b/src/app/components/HowToPlay/TutorialOverlay.tsx
@@ -95,7 +95,8 @@ export function TutorialOverlay({
             <h3 className={styles.sectionTitle}>📱 Zoom & Pan</h3>
             <p>
               Pinch with two fingers to zoom in or out on the board. Drag with two fingers
-              to pan around. Great for larger puzzles!
+              to pan, or drag with one finger on empty space when zoomed. Great for larger
+              puzzles!
             </p>
           </div>
         )}

--- a/src/app/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/app/components/ShortcutsModal/ShortcutsModal.tsx
@@ -104,6 +104,12 @@ export function ShortcutsModal({ isOpen, onClose }: ShortcutsModalProps) {
                   </td>
                   <td className={styles.action}>Pan (iOS & Android)</td>
                 </tr>
+                <tr>
+                  <td className={styles.keys}>
+                    <kbd className={styles.key}>Single-finger drag</kbd> on empty space
+                  </td>
+                  <td className={styles.action}>Pan when zoomed (iOS & Android)</td>
+                </tr>
               </tbody>
             </table>
             <p className={styles.navNote}>

--- a/src/app/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/app/components/ShortcutsModal/ShortcutsModal.tsx
@@ -77,20 +77,32 @@ export function ShortcutsModal({ isOpen, onClose }: ShortcutsModalProps) {
           </div>
 
           <div className={styles.mouseSection}>
-            <h3>Navigation Tips</h3>
+            <h3>Zoom & Pan</h3>
             <table className={styles.table}>
               <tbody>
                 <tr>
                   <td className={styles.keys}>
-                    <kbd className={styles.key}>Scroll Wheel</kbd>
+                    <kbd className={styles.key}>Scroll Wheel</kbd> on board
                   </td>
-                  <td className={styles.action}>Scroll page (no zoom)</td>
+                  <td className={styles.action}>Zoom in/out (desktop)</td>
                 </tr>
                 <tr>
                   <td className={styles.keys}>
-                    <kbd className={styles.key}>Pinch</kbd>
+                    <kbd className={styles.key}>Middle mouse</kbd> + Drag
                   </td>
-                  <td className={styles.action}>Browser zoom (touch)</td>
+                  <td className={styles.action}>Pan (desktop)</td>
+                </tr>
+                <tr>
+                  <td className={styles.keys}>
+                    <kbd className={styles.key}>Two-finger pinch</kbd>
+                  </td>
+                  <td className={styles.action}>Zoom in/out (iOS & Android)</td>
+                </tr>
+                <tr>
+                  <td className={styles.keys}>
+                    <kbd className={styles.key}>Two-finger drag</kbd>
+                  </td>
+                  <td className={styles.action}>Pan (iOS & Android)</td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/data/changelog.ts
+++ b/src/app/data/changelog.ts
@@ -1,11 +1,12 @@
 /** Changelog for What's New popup. Bump CHANGELOG_VERSION when adding entries. */
-export const CHANGELOG_VERSION = "2";
+export const CHANGELOG_VERSION = "3";
 const STORAGE_KEY = "phuzzle:lastSeenChangelog";
 
 export const CHANGELOG_ENTRIES: { title: string; items: string[] }[] = [
   {
     title: "What's New",
     items: [
+      "📱 Two-finger pinch zoom – Zoom and pan on mobile (iOS & Android) now works reliably",
       "📸 Camera capture – Take a photo directly for your puzzle",
       "📰 What's New popup – Stay updated on the latest features",
       "📊 Stats & Achievements – Track progress, compete on leaderboards",

--- a/src/app/screens/Play/PlayScreen.module.css
+++ b/src/app/screens/Play/PlayScreen.module.css
@@ -726,7 +726,48 @@
 
 .headerMenuChevron {
   flex-shrink: 0;
+  opacity: 0.6;
   transition: transform 0.15s ease;
+}
+
+.headerMenuSubmenuTrigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 44px;
+  padding: 12px 16px;
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: 14px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.headerMenuSubmenuTrigger:hover {
+  background: var(--color-bg-card);
+}
+
+.headerMenuBack {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 44px;
+  padding: 12px 16px;
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: 14px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.headerMenuBack:hover {
+  background: var(--color-bg-card);
 }
 
 .headerMenuHelpSubmenu {

--- a/src/app/screens/Play/components/HeaderMenu.tsx
+++ b/src/app/screens/Play/components/HeaderMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Menu } from "lucide-react";
+import { Menu, ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/Button/Button";
 import { ThemeToggle } from "@/components/ThemeToggle/ThemeToggle";
 import styles from "../PlayScreen.module.css";
@@ -8,9 +8,16 @@ import {
   buildMenuItems,
   type HeaderMenuProps,
   type MenuItemConfig,
+  type SubMenuId,
 } from "./headerMenuConfig";
 
 export type { HeaderMenuProps } from "./headerMenuConfig";
+
+const SUB_MENU_LABELS: Record<SubMenuId, string> = {
+  game: "Game",
+  view: "View",
+  audio: "Audio",
+};
 
 /**
  * Single source of truth for the "hamburger" menu.
@@ -19,8 +26,13 @@ export type { HeaderMenuProps } from "./headerMenuConfig";
 export function HeaderMenu(props: HeaderMenuProps) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const [activeSubMenu, setActiveSubMenu] = useState<SubMenuId | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const items = buildMenuItems(props, setOpen, (path) => navigate(path));
+
+  useEffect(() => {
+    if (!open) setActiveSubMenu(null);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -30,7 +42,10 @@ export function HeaderMenu(props: HeaderMenuProps) {
       setOpen(false);
     };
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") {
+        if (activeSubMenu) setActiveSubMenu(null);
+        else setOpen(false);
+      }
     };
     window.addEventListener("pointerdown", onPointerDown);
     window.addEventListener("keydown", onKeyDown);
@@ -38,7 +53,7 @@ export function HeaderMenu(props: HeaderMenuProps) {
       window.removeEventListener("pointerdown", onPointerDown);
       window.removeEventListener("keydown", onKeyDown);
     };
-  }, [open]);
+  }, [open, activeSubMenu]);
 
   const visibleItems = items.filter((i) => i.visible);
   const navItems = visibleItems.filter((i) => i.section === "nav");
@@ -50,6 +65,17 @@ export function HeaderMenu(props: HeaderMenuProps) {
       }),
     );
   const otherItems = visibleItems.filter((i) => i.section === "other");
+
+  const topLevelSettings = settingsItems.filter((i) => !i.subMenu);
+  const subMenuItems = settingsItems
+    .filter((i) => i.subMenu === activeSubMenu)
+    .sort((a, b) =>
+      (a.sortKey ?? a.label).localeCompare(b.sortKey ?? b.label, undefined, {
+        sensitivity: "base",
+      }),
+    );
+
+  const hasSubMenuItems = (id: SubMenuId) => settingsItems.some((i) => i.subMenu === id);
 
   const closeAnd = (fn: () => void) => () => {
     setOpen(false);
@@ -82,6 +108,76 @@ export function HeaderMenu(props: HeaderMenuProps) {
     );
   };
 
+  const renderMainMenu = () => (
+    <>
+      {navItems.map(renderItem)}
+      <div className={styles.headerMenuDivider} />
+      <div className={styles.headerMenuSection}>Help</div>
+      <button
+        type="button"
+        className={styles.headerMenuItem}
+        role="menuitem"
+        onClick={closeAnd(props.onShowHelpChoice)}
+      >
+        Help
+      </button>
+      <div className={styles.headerMenuDivider} />
+      <div className={styles.headerMenuSection}>Settings</div>
+      {hasSubMenuItems("game") && (
+        <button
+          type="button"
+          className={styles.headerMenuSubmenuTrigger}
+          role="menuitem"
+          onClick={() => setActiveSubMenu("game")}
+        >
+          {SUB_MENU_LABELS.game}
+          <ChevronRight size={16} className={styles.headerMenuChevron} />
+        </button>
+      )}
+      {hasSubMenuItems("view") && (
+        <button
+          type="button"
+          className={styles.headerMenuSubmenuTrigger}
+          role="menuitem"
+          onClick={() => setActiveSubMenu("view")}
+        >
+          {SUB_MENU_LABELS.view}
+          <ChevronRight size={16} className={styles.headerMenuChevron} />
+        </button>
+      )}
+      {hasSubMenuItems("audio") && (
+        <button
+          type="button"
+          className={styles.headerMenuSubmenuTrigger}
+          role="menuitem"
+          onClick={() => setActiveSubMenu("audio")}
+        >
+          {SUB_MENU_LABELS.audio}
+          <ChevronRight size={16} className={styles.headerMenuChevron} />
+        </button>
+      )}
+      {topLevelSettings.map(renderItem)}
+      {otherItems.map(renderItem)}
+    </>
+  );
+
+  const renderSubMenu = () => (
+    <>
+      <button
+        type="button"
+        className={styles.headerMenuBack}
+        role="menuitem"
+        onClick={() => setActiveSubMenu(null)}
+      >
+        <ChevronLeft size={16} />
+        Back
+      </button>
+      <div className={styles.headerMenuDivider} />
+      <div className={styles.headerMenuSection}>{SUB_MENU_LABELS[activeSubMenu!]}</div>
+      {subMenuItems.map(renderItem)}
+    </>
+  );
+
   return (
     <div className={styles.headerMenuWrap} ref={rootRef}>
       <Button
@@ -97,21 +193,7 @@ export function HeaderMenu(props: HeaderMenuProps) {
 
       {open && (
         <div className={styles.headerMenuPanel} role="menu">
-          {navItems.map(renderItem)}
-          <div className={styles.headerMenuDivider} />
-          <div className={styles.headerMenuSection}>Help</div>
-          <button
-            type="button"
-            className={styles.headerMenuItem}
-            role="menuitem"
-            onClick={closeAnd(props.onShowHelpChoice)}
-          >
-            Help
-          </button>
-          <div className={styles.headerMenuDivider} />
-          <div className={styles.headerMenuSection}>Settings</div>
-          {settingsItems.map(renderItem)}
-          {otherItems.map(renderItem)}
+          {activeSubMenu ? renderSubMenu() : renderMainMenu()}
         </div>
       )}
     </div>

--- a/src/app/screens/Play/components/headerMenuConfig.tsx
+++ b/src/app/screens/Play/components/headerMenuConfig.tsx
@@ -41,6 +41,8 @@ export type HeaderMenuProps = {
   onToggleDebug: () => void;
 };
 
+export type SubMenuId = "game" | "view" | "audio";
+
 export type MenuItemConfig = {
   id: string;
   label: string;
@@ -50,6 +52,8 @@ export type MenuItemConfig = {
   onClick: () => void;
   isTheme?: boolean;
   sortKey?: string;
+  /** When set, item appears in this sub-menu instead of top-level settings */
+  subMenu?: SubMenuId;
 };
 
 const TIME_MODE_LABELS: Record<TimeMode, string> = {
@@ -108,6 +112,7 @@ export function buildMenuItems(
       label: "Debug overlay",
       sortKey: "Debug overlay",
       onClick: c(props.onToggleDebug),
+      /* No subMenu - stays at top level */
     },
     {
       id: "fullscreen",
@@ -116,6 +121,7 @@ export function buildMenuItems(
       label: props.isFullscreen ? "Exit fullscreen" : "Fullscreen",
       sortKey: "Fullscreen",
       onClick: c(props.onToggleFullscreen),
+      subMenu: "view",
     },
     {
       id: "timeMode",
@@ -127,6 +133,7 @@ export function buildMenuItems(
         const order: TimeMode[] = ["elapsed", "countdown", "active", "relaxed", "best"];
         props.setTimeMode(order[(order.indexOf(props.timeMode) + 1) % order.length]);
       }),
+      subMenu: "game",
     },
     {
       id: "countdownMinutes",
@@ -141,6 +148,7 @@ export function buildMenuItems(
         const i = idx >= 0 ? idx : 0;
         props.setCountdownMinutes(COUNTDOWN_OPTIONS[(i + 1) % COUNTDOWN_OPTIONS.length]);
       }),
+      subMenu: "game",
     },
     {
       id: "ghost",
@@ -149,6 +157,7 @@ export function buildMenuItems(
       label: props.showGhostHint ? "Ghost hint: on" : "Ghost hint: off",
       sortKey: "Ghost hint",
       onClick: c(props.onToggleGhostHint),
+      subMenu: "game",
     },
     {
       id: "haptics",
@@ -157,8 +166,8 @@ export function buildMenuItems(
       label: props.hapticsEnabled ? "Haptics: on" : "Haptics: off",
       sortKey: "Haptics",
       onClick: c(props.onToggleHaptics),
+      subMenu: "audio",
     },
-    /* Help is rendered as expandable submenu in HeaderMenu (How to Play / Keyboard shortcuts) */
     {
       id: "theme",
       section: "settings",
@@ -167,6 +176,7 @@ export function buildMenuItems(
       sortKey: "Theme",
       onClick: () => setOpen(false),
       isTheme: true,
+      subMenu: "view",
     },
     {
       id: "lock",
@@ -175,6 +185,7 @@ export function buildMenuItems(
       label: props.pieceLockingEnabled ? "Lock pieces: on" : "Lock pieces: off",
       sortKey: "Lock pieces",
       onClick: c(props.onTogglePieceLocking),
+      subMenu: "game",
     },
     {
       id: "preview",
@@ -183,6 +194,7 @@ export function buildMenuItems(
       label: props.showPreview ? "Hide preview" : "Show preview",
       sortKey: "Show preview",
       onClick: c(props.onTogglePreview),
+      subMenu: "view",
     },
     {
       id: "sound",
@@ -191,6 +203,7 @@ export function buildMenuItems(
       label: props.soundEnabled ? "Sound: on" : "Sound: off",
       sortKey: "Sound",
       onClick: c(props.onToggleSound),
+      subMenu: "audio",
     },
   ];
 }

--- a/src/app/screens/Play/hooks/usePointerHandlers.ts
+++ b/src/app/screens/Play/hooks/usePointerHandlers.ts
@@ -41,6 +41,7 @@ export function usePointerHandlers(args: {
     handlePanMove: (x: number, y: number) => void;
     endPan: () => void;
     isPanning: () => boolean;
+    isZoomedOrPanned?: () => boolean;
     startPinch: (
       p1: { clientX: number; clientY: number },
       p2: { clientX: number; clientY: number },
@@ -183,7 +184,19 @@ export function usePointerHandlers(args: {
       const st = manager.getState();
       const boardPieces = st.pieces.filter((p) => !p.inTray);
       const pieceId = pickPieceId(ctx2d, boardPieces, pickX, pickY);
-      if (!pieceId) return;
+      if (!pieceId) {
+        // Empty space — single-finger pan when zoomed (touch only)
+        if (viewport && e.pointerType === "touch" && viewport.isZoomedOrPanned?.()) {
+          e.preventDefault();
+          viewport.startPan(e.clientX, e.clientY);
+          try {
+            (canvasRef.current as CanvasWithTouch).setPointerCapture(e.pointerId);
+          } catch {
+            /* ignore */
+          }
+        }
+        return;
+      }
 
       const piece = st.pieces.find((p) => p.id === pieceId);
       if (piece?.locked) return;

--- a/src/app/screens/Play/hooks/usePointerHandlers.ts
+++ b/src/app/screens/Play/hooks/usePointerHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type React from "react";
 import { pickPieceId } from "@/puzzle/canvas/pickPiece";
 import type { PuzzleManager } from "@/puzzle/PuzzleManager";
@@ -13,6 +13,7 @@ import {
   handleTouchDown,
   handleTouchMove,
   handleTouchUp,
+  resetTouchState,
 } from "./pointerHandlers/touchHandlers";
 import {
   handleMouseDown,
@@ -40,6 +41,17 @@ export function usePointerHandlers(args: {
     handlePanMove: (x: number, y: number) => void;
     endPan: () => void;
     isPanning: () => boolean;
+    startPinch: (
+      p1: { clientX: number; clientY: number },
+      p2: { clientX: number; clientY: number },
+    ) => void;
+    handlePinchMove: (
+      p1: { clientX: number; clientY: number },
+      p2: { clientX: number; clientY: number },
+      boardRect: DOMRect,
+    ) => void;
+    endPinch: () => void;
+    isPinching: () => boolean;
   };
 }) {
   const {
@@ -106,9 +118,45 @@ export function usePointerHandlers(args: {
     viewport,
   };
 
+  const activePointersRef = useRef<
+    Map<number, { clientX: number; clientY: number; pointerType: string }>
+  >(new Map());
+
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
       if (!manager || !canvasRef.current || !boardRef.current) return;
+
+      activePointersRef.current.set(e.pointerId, {
+        clientX: e.clientX,
+        clientY: e.clientY,
+        pointerType: e.pointerType,
+      });
+
+      const touchPointers = [...activePointersRef.current.entries()]
+        .filter(([, p]) => p.pointerType === "touch")
+        .map(([id, p]) => ({ id, ...p }));
+      if (viewport && touchPointers.length >= 2 && e.pointerType === "touch") {
+        const [p1, p2] = touchPointers;
+        const canvas = canvasRef.current as CanvasWithTouch;
+        resetTouchState(canvas);
+        onDragPreview?.(null);
+        selectedIdRef.current = null;
+        setSelectedPieceId(null);
+        manager.pointerUp();
+        setState(manager.getState());
+        try {
+          canvas.releasePointerCapture(p1.id);
+          canvas.releasePointerCapture(p2.id);
+        } catch {
+          /* ignore */
+        }
+        viewport.startPinch(
+          { clientX: p1.clientX, clientY: p1.clientY },
+          { clientX: p2.clientX, clientY: p2.clientY },
+        );
+        e.preventDefault();
+        return;
+      }
 
       // Middle mouse: start pan
       if (e.button === 1 && viewport) {
@@ -176,11 +224,31 @@ export function usePointerHandlers(args: {
       bump,
       canRotatePiece,
       screenToBoard,
+      viewport,
+      onDragPreview,
+      setState,
     ],
   );
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
+      activePointersRef.current.set(e.pointerId, {
+        clientX: e.clientX,
+        clientY: e.clientY,
+        pointerType: e.pointerType,
+      });
+
+      if (viewport?.isPinching?.()) {
+        const touchPointers = [...activePointersRef.current.entries()]
+          .filter(([, p]) => p.pointerType === "touch")
+          .map(([, p]) => p);
+        if (touchPointers.length >= 2 && boardRef.current) {
+          const boardRect = boardRef.current.getBoundingClientRect();
+          viewport.handlePinchMove(touchPointers[0], touchPointers[1], boardRect);
+        }
+        e.preventDefault();
+        return;
+      }
       if (viewport?.isPanning?.()) {
         viewport.handlePanMove(e.clientX, e.clientY);
         return;
@@ -201,6 +269,13 @@ export function usePointerHandlers(args: {
 
   const handlePointerUp = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
+      activePointersRef.current.delete(e.pointerId);
+      if (viewport?.isPinching?.()) {
+        if (activePointersRef.current.size < 2) {
+          viewport.endPinch();
+        }
+        return;
+      }
       if (viewport?.isPanning?.()) {
         viewport.endPan();
         try {
@@ -221,7 +296,7 @@ export function usePointerHandlers(args: {
 
       handleMouseUp(e, ctx, isPointerOverTray, screenToBoard);
     },
-    [manager, canvasRef, canRotatePiece, isPointerOverTray, screenToBoard],
+    [manager, canvasRef, canRotatePiece, isPointerOverTray, screenToBoard, viewport],
   );
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
@@ -230,6 +305,13 @@ export function usePointerHandlers(args: {
 
   const handlePointerCancel = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
+      activePointersRef.current.delete(e.pointerId);
+      if (viewport?.isPinching?.()) {
+        if (activePointersRef.current.size < 2) {
+          viewport.endPinch();
+        }
+        return;
+      }
       if (viewport?.isPanning?.()) {
         viewport.endPan();
         return;
@@ -281,6 +363,81 @@ export function usePointerHandlers(args: {
       window.removeEventListener("pointercancel", onWinUp);
     };
   }, [manager, onDragPreview, setState]);
+
+  // Touch-event-based pinch zoom for iOS Safari.
+  // Pointer events are unreliable for multi-touch on iOS (second finger often doesn't fire).
+  // Native touch events work reliably.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const board = boardRef.current;
+    if (!canvas || !board || !viewport) return;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length >= 2) {
+        const p1 = e.touches[0];
+        const p2 = e.touches[1];
+        const canvasWithTouch = canvas as CanvasWithTouch;
+        resetTouchState(canvasWithTouch);
+        onDragPreview?.(null);
+        selectedIdRef.current = null;
+        setSelectedPieceId(null);
+        manager?.pointerUp();
+        if (manager) setState(manager.getState());
+        viewport.startPinch(
+          { clientX: p1.clientX, clientY: p1.clientY },
+          { clientX: p2.clientX, clientY: p2.clientY },
+        );
+        e.preventDefault();
+      }
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (viewport.isPinching() && e.touches.length >= 2 && board) {
+        const p1 = e.touches[0];
+        const p2 = e.touches[1];
+        const boardRect = board.getBoundingClientRect();
+        viewport.handlePinchMove(
+          { clientX: p1.clientX, clientY: p1.clientY },
+          { clientX: p2.clientX, clientY: p2.clientY },
+          boardRect,
+        );
+        e.preventDefault();
+      }
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      if (viewport.isPinching() && e.touches.length < 2) {
+        viewport.endPinch();
+      }
+    };
+
+    const onTouchCancel = (e: TouchEvent) => {
+      if (viewport.isPinching() && e.touches.length < 2) {
+        viewport.endPinch();
+      }
+    };
+
+    canvas.addEventListener("touchstart", onTouchStart, { passive: false });
+    canvas.addEventListener("touchmove", onTouchMove, { passive: false });
+    canvas.addEventListener("touchend", onTouchEnd, { passive: true });
+    canvas.addEventListener("touchcancel", onTouchCancel, { passive: true });
+
+    return () => {
+      canvas.removeEventListener("touchstart", onTouchStart);
+      canvas.removeEventListener("touchmove", onTouchMove);
+      canvas.removeEventListener("touchend", onTouchEnd);
+      canvas.removeEventListener("touchcancel", onTouchCancel);
+    };
+  }, [
+    canvasRef,
+    boardRef,
+    viewport,
+    manager,
+    onDragPreview,
+    setState,
+    setSelectedPieceId,
+    selectedIdRef,
+  ]);
 
   return {
     handlePointerDown,

--- a/src/app/screens/Play/hooks/useViewport.ts
+++ b/src/app/screens/Play/hooks/useViewport.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 
 const isPanningRef = { current: false };
+const isPinchingRef = { current: false };
 
 const MIN_SCALE = 0.25;
 const MAX_SCALE = 4;
@@ -51,6 +52,16 @@ export function useViewport() {
     panY: number;
   } | null>(null);
 
+  const pinchStartRef = useRef<{
+    centerX: number;
+    centerY: number;
+    distance: number;
+    scale: number;
+    panX: number;
+    panY: number;
+  } | null>(null);
+  const pinchPrevCenterRef = useRef<{ x: number; y: number } | null>(null);
+
   const startPan = useCallback((clientX: number, clientY: number) => {
     isPanningRef.current = true;
     const v = viewportRef.current;
@@ -71,6 +82,68 @@ export function useViewport() {
       panY: start.panY + (clientY - start.clientY),
     }));
   }, []);
+
+  const startPinch = useCallback(
+    (
+      p1: { clientX: number; clientY: number },
+      p2: { clientX: number; clientY: number },
+    ) => {
+      isPinchingRef.current = true;
+      const v = viewportRef.current;
+      const centerX = (p1.clientX + p2.clientX) / 2;
+      const centerY = (p1.clientY + p2.clientY) / 2;
+      const distance = Math.hypot(p2.clientX - p1.clientX, p2.clientY - p1.clientY);
+      pinchStartRef.current = {
+        centerX,
+        centerY,
+        distance,
+        scale: v.scale,
+        panX: v.panX,
+        panY: v.panY,
+      };
+      pinchPrevCenterRef.current = { x: centerX, y: centerY };
+    },
+    [],
+  );
+
+  const handlePinchMove = useCallback(
+    (
+      p1: { clientX: number; clientY: number },
+      p2: { clientX: number; clientY: number },
+      boardRect: DOMRect,
+    ) => {
+      const start = pinchStartRef.current;
+      const prevCenter = pinchPrevCenterRef.current;
+      if (!start || !isPinchingRef.current) return;
+      const centerX = (p1.clientX + p2.clientX) / 2;
+      const centerY = (p1.clientY + p2.clientY) / 2;
+      const distance = Math.hypot(p2.clientX - p1.clientX, p2.clientY - p1.clientY);
+      if (distance < 1) return;
+      const scaleFactor = distance / start.distance;
+      const newScale = Math.min(
+        MAX_SCALE,
+        Math.max(MIN_SCALE, start.scale * scaleFactor),
+      );
+      const v = viewportRef.current;
+      const cssX = centerX - boardRect.left;
+      const cssY = centerY - boardRect.top;
+      const zoomScaleFactor = newScale / v.scale;
+      const centerDeltaX = prevCenter ? centerX - prevCenter.x : 0;
+      const centerDeltaY = prevCenter ? centerY - prevCenter.y : 0;
+      const newPanX = cssX - (cssX - v.panX) * zoomScaleFactor + centerDeltaX;
+      const newPanY = cssY - (cssY - v.panY) * zoomScaleFactor + centerDeltaY;
+      pinchPrevCenterRef.current = { x: centerX, y: centerY };
+      setViewport({ scale: newScale, panX: newPanX, panY: newPanY });
+    },
+    [],
+  );
+
+  const endPinch = useCallback(() => {
+    isPinchingRef.current = false;
+    pinchStartRef.current = null;
+  }, []);
+
+  const isPinching = useCallback(() => isPinchingRef.current, []);
 
   const endPan = useCallback(() => {
     isPanningRef.current = false;
@@ -118,5 +191,9 @@ export function useViewport() {
     handlePanMove,
     endPan,
     isPanning,
+    startPinch,
+    handlePinchMove,
+    endPinch,
+    isPinching,
   };
 }

--- a/src/app/screens/Play/hooks/useViewport.ts
+++ b/src/app/screens/Play/hooks/useViewport.ts
@@ -152,6 +152,11 @@ export function useViewport() {
 
   const isPanning = useCallback(() => isPanningRef.current, []);
 
+  const isZoomedOrPanned = useCallback(() => {
+    const v = viewportRef.current;
+    return v.scale !== 1 || v.panX !== 0 || v.panY !== 0;
+  }, []);
+
   const reset = useCallback(() => {
     setViewport({ scale: 1, panX: 0, panY: 0 });
   }, []);
@@ -191,6 +196,7 @@ export function useViewport() {
     handlePanMove,
     endPan,
     isPanning,
+    isZoomedOrPanned,
     startPinch,
     handlePinchMove,
     endPinch,


### PR DESCRIPTION
## Description

Improves mobile touch handling, adds settings sub-menus to reduce menu length, and improves zoom/pan behavior.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

- [x] I have tested these changes locally
- [x] I have tested these changes in multiple browsers/environments if applicable

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if needed

## How to Test

### 1. Two-finger pinch zoom

- Go to play screen.
- Put two fingers on the board.
- Pinch in/out.
- Board should zoom in/out.
- Works on iPhone Safari.

### 2.  Two-finger pan

- With two fingers on the board, drag without changing pinch distance.
- Board should pan.

### 3. Single-finger pan when zoomed

- Zoom in with two-finger pinch.
- Lift fingers.
- Drag one finger on empty board space.
- Board should pan.
- Drag one finger on a piece: piece should move, not pan.

### 4.  Tap to rotate

- Tap a piece (no drag).
- Piece should rotate 90°.

### 5.  One-finger drag

- Drag a piece.
- Piece should move.

### Desktop
### 1.  Scroll wheel zoom

- Hover over board and scroll.
- Board should zoom toward cursor.

### 2.  Middle-click pan

- Middle-click and drag.
- Board should pan.

### 3.  Settings sub-menus
- Open Menu (☰).
- Confirm Game, View, Audio entries with chevrons.
- Tap Game → see Time, Countdown, Ghost hint, Lock pieces.
- Tap Back → return to main menu.
- Tap View → see Theme, Preview, Fullscreen.
- Tap Audio → see Sound, Haptics.
- Press Escape → sub-menu closes first.

### 4. Help modal
- Open Help → Keyboard Shortcuts.
- Zoom & Pan section shows single-finger pan when zoomed.
- Zoom & Pan section shows two-finger pinch/drag for mobile.

### General
- Start a puzzle, zoom in, drag pieces, pan with one finger on empty space.
- No visible stuck drags or ghost pieces.
- Undo/redo still works.
- Piece tray behavior unchanged.

## Screenshots (if applicable)

**N/A**

## Additional Notes

**N/A**
